### PR TITLE
ci: fix creating GitHub release notes

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -277,7 +277,9 @@ jobs:
   release-toolkit:
     name: 'Releasing @scion/toolkit'
     if: ${{ needs.toolkit-release-guard.outputs.should-release == 'true' }}
-    needs: toolkit-release-guard
+    needs:
+      - build-libs
+      - toolkit-release-guard
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -300,7 +302,9 @@ jobs:
   release-components:
     name: 'Releasing @scion/components'
     if: ${{ needs.components-release-guard.outputs.should-release == 'true' }}
-    needs: components-release-guard
+    needs:
+      - build-libs
+      - components-release-guard
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Previously, releasing to GitHub failed because we did not declare a dependency on the 'build-libs' step, required to initialize the $VERSION variable.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our [guidelines](https://github.com/SchweizerischeBundesbahnen/scion-toolkit/blob/master/CONTRIBUTING.md)
- [ ] Tests for the changes have been added
- [ ] Docs have been added or updated


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Fix
- [ ] Feature
- [ ] Documentation
- [ ] Refactoring (changes that neither fixes a bug nor adds a feature)
- [ ] Performance (changes that improve performance)
- [ ] Test (adding missing tests, refactoring tests; no production code change)
- [ ] Chore (other changes like formatting, updating the license, removal of deprecations, etc)
- [ ] Deps (changes related to updating dependencies)
- [x] CI (changes to our CI configuration files and scripts)
- [ ] Revert (revert of a previous commit)
- [ ] Release (publish a new release)
- [ ] Other... Please describe:

## Issue

Issue Number: #

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
