### PR TITLE
[DO NOT MERGE] perf(components/viewport): avoid change detection cycle when scrolling the viewport

### DIFF
--- a/docs/site/tools/viewport.md
+++ b/docs/site/tools/viewport.md
@@ -79,12 +79,12 @@ The viewport component displays scrollbars when its content overflows. Scrollbar
   
 #### Inputs:
 - **scrollbarStyle**\
-  Controls whether to use native scrollbars or, which is by default, emulated scrollbars that sit on top of the viewport client. In the latter, the viewport client remains natively scrollable.\
+  Controls if to use the native scrollbar or a scrollbar that sits on top of the viewport. Defaults to `on-top`.
   Supported values are `native`, `on-top`, or `hidden`.
 
 #### Events:
 - **scroll**\
-  Emits upon a scroll event.
+  Emits when the viewport is scrolled. The event is emitted outside the Angular zone to avoid unnecessary change detection cycles.
 
 </details>
 

--- a/projects/scion/components/viewport/src/viewport.component.html
+++ b/projects/scion/components/viewport/src/viewport.component.html
@@ -3,8 +3,7 @@
      class="viewport"
      tabindex="-1"
      sciScrollable [sciScrollableDisplayNativeScrollbar]="scrollbarStyle() === 'native'"
-     cdkScrollable
-     (scroll)="onScroll($event)">
+     cdkScrollable>
   <div #viewport_client class="viewport-client" part="content">
     <slot></slot>
   </div>

--- a/projects/scion/components/viewport/src/viewport.component.ts
+++ b/projects/scion/components/viewport/src/viewport.component.ts
@@ -8,12 +8,14 @@
  *  SPDX-License-Identifier: EPL-2.0
  */
 
-import {Component, ElementRef, HostListener, inject, input, output, viewChild, ViewEncapsulation} from '@angular/core';
+import {Component, effect, ElementRef, HostListener, inject, input, NgZone, output, untracked, viewChild, ViewEncapsulation} from '@angular/core';
 import {SciNativeScrollbarTrackSizeProvider} from './native-scrollbar-track-size-provider.service';
 import {coerceElement} from '@angular/cdk/coercion';
 import {SciScrollableDirective} from './scrollable.directive';
 import {SciScrollbarComponent} from './scrollbar/scrollbar.component';
 import {ScrollingModule} from '@angular/cdk/scrolling';
+import {fromEvent} from 'rxjs';
+import {subscribeIn} from '@scion/toolkit/operators';
 
 /**
  * Represents a viewport with slotted content (`<ng-content>`) used as scrollable content. By default, content is added to a CSS grid layout.
@@ -102,25 +104,22 @@ export class SciViewportComponent {
   protected nativeScrollbarTrackSizeProvider = inject(SciNativeScrollbarTrackSizeProvider);
 
   /**
-   * Controls whether to use native scrollbars or, which is by default, emulated scrollbars that sit on top of the viewport client.
-   * In the latter, the viewport client remains natively scrollable.
+   * Controls if to use the native scrollbar or a scrollbar that sits on top of the viewport. Defaults to `on-top`.
    */
   public scrollbarStyle = input<ScrollbarStyle>('on-top');
 
   /**
-   * Emits upon a scroll event.
-   *
-   * You can add [sciDimension] directive to the viewport or viewport client to be notified about layout changes.
+   * Emits when the viewport is scrolled. The event is emitted outside the Angular zone to avoid unnecessary change detection cycles.
    */
   public scroll = output<Event>();
+
+  constructor() {
+    this.installScrollEmitter();
+  }
 
   @HostListener('focus')
   public focus(): void { // do not rename to expose the same focus method like `HTMLElement.focus()`.
     this.viewportElement.focus();
-  }
-
-  protected onScroll(event: Event): void {
-    this.scroll.emit(event);
   }
 
   /**
@@ -279,6 +278,22 @@ export class SciViewportComponent {
     } while (el !== this._host);
 
     return offset;
+  }
+
+  /**
+   * Emits when the scroll position changes.
+   */
+  private installScrollEmitter(): void {
+    const zone = inject(NgZone);
+    effect(onCleanup => {
+      const viewport = this._viewport();
+      untracked(() => {
+        const subscription = fromEvent(viewport.nativeElement, 'scroll')
+          .pipe(subscribeIn(fn => zone.runOutsideAngular(fn)))
+          .subscribe(event => this.scroll.emit(event));
+        onCleanup(() => subscription.unsubscribe());
+      });
+    });
   }
 }
 


### PR DESCRIPTION
**Wait merging this PR until releasing v19.0.0 because introducing a breaking change.**

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our [guidelines](https://github.com/SchweizerischeBundesbahnen/scion-toolkit/blob/master/CONTRIBUTING.md)
- [x] Tests for the changes have been added
- [x] Docs have been added or updated


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Fix
- [ ] Feature
- [ ] Documentation
- [ ] Refactoring (changes that neither fixes a bug nor adds a feature)
- [x] Performance (changes that improve performance)
- [ ] Test (adding missing tests, refactoring tests; no production code change)
- [ ] Chore (other changes like formatting, updating the license, removal of deprecations, etc)
- [ ] Deps (changes related to updating dependencies)
- [ ] CI (changes to our CI configuration files and scripts)
- [ ] Revert (revert of a previous commit)
- [ ] Release (publish a new release)
- [ ] Other... Please describe:

## Does this PR introduce a breaking change?

- [x] Yes
- [ ] No

**BREAKING CHANGE**: Changed viewport to emit scroll events outside the Angular zone.

To handle scroll events inside the Angular zone, e.g., if updating component bindings, manually synchronize with the Angular zone, as follows:

```ts
inject(NgZone).run(() => {
  ...
});
```